### PR TITLE
Update to Minecraft 26.1.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,8 @@
 plugins {
     id 'net.fabricmc.fabric-loom' version "${loom_version}"
-    id 'maven-publish'
 }
 
-version = project.mod_version
+version = "${project.mod_version}+26.1.x"
 group = project.maven_group
 
 base {
@@ -45,51 +44,19 @@ processResources {
     }
 }
 
-def targetJavaVersion = 25
 tasks.withType(JavaCompile).configureEach {
-    // ensure that the encoding is set to UTF-8, no matter what the system default is
-    // this fixes some edge cases with special characters not displaying correctly
-    // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-    // If Javadoc is generated, this must be specified in that task too.
-    it.options.encoding = "UTF-8"
-    if (targetJavaVersion >= 10 || JavaVersion.current().isJava10Compatible()) {
-        it.options.release.set(targetJavaVersion)
-    }
+    it.options.release = 25
 }
 
 java {
-    def javaVersion = JavaVersion.toVersion(targetJavaVersion)
-    if (JavaVersion.current() < javaVersion) {
-        toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
-    }
-    // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-    // if it is present.
-    // If you remove this line, sources will not be generated.
-    withSourcesJar()
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {
+    inputs.property "archivesName", project.base.archivesName
+
     from("LICENSE") {
-        rename { "${it}_${base.archivesName.get()}"}
-    }
-}
-
-// configure the maven publication
-publishing {
-    publications {
-        create("mavenJava", MavenPublication) {
-            artifactId = project.archives_base_name
-            from components.java
-        }
-    }
-
-    // See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
-    repositories {
-        // Add repositories to publish to here.
-        // Notice: This block does NOT have the same function as the block in the top level.
-        // The repositories here will be used for publishing your artifact, not for
-        // retrieving dependencies.
+        rename { "${it}_${inputs.properties.archivesName}"}
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.14-SNAPSHOT'
+    id 'net.fabricmc.fabric-loom' version "${loom_version}"
     id 'maven-publish'
 }
 
@@ -18,33 +18,34 @@ repositories {
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 
-    modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}") {
+    implementation("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}") {
         exclude(group: "net.fabricmc.fabric-api")
     }
 
-    modApi "com.terraformersmc:modmenu:${project.modmenu_version}"
+    implementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 }
 
 processResources {
     inputs.property "version", project.version
     inputs.property "minecraft_version", project.minecraft_version
     inputs.property "loader_version", project.loader_version
+    inputs.property "cloth_version", project.cloth_version
     filteringCharset "UTF-8"
 
     filesMatching("fabric.mod.json") {
         expand "version": project.version,
                 "minecraft_version": project.minecraft_version,
-                "loader_version": project.loader_version
+                "loader_version": project.loader_version,
+                "cloth_version": project.cloth_version
     }
 }
 
-def targetJavaVersion = 21
+def targetJavaVersion = 25
 tasks.withType(JavaCompile).configureEach {
     // ensure that the encoding is set to UTF-8, no matter what the system default is
     // this fixes some edge cases with special characters not displaying correctly
@@ -65,6 +66,8 @@ java {
     // if it is present.
     // If you remove this line, sources will not be generated.
     withSourcesJar()
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ loader_version=0.19.2
 loom_version=1.16-SNAPSHOT
 
 # Mod Properties
-mod_version=1.2+26.1.2
+mod_version=1.2
 maven_group=io.github.thevoidblock
 archives_base_name = NoFortuneChest
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,20 +2,20 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-# check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.4
-loader_version=0.18.4
+# check these on https://fabricmc.net/develop
+minecraft_version=26.1.2
+loader_version=0.19.2
+loom_version=1.16-SNAPSHOT
 
 # Mod Properties
-mod_version=1.2+1.21.11
+mod_version=1.2+26.1.2
 maven_group=io.github.thevoidblock
 archives_base_name = NoFortuneChest
 
 # Dependencies
-# check this on https://modmuss50.me/fabric.html
-fabric_api_version=0.141.1+1.21.11
+# check this on https://fabricmc.net/develop
+fabric_api_version=0.150.0+26.1.2
 
 # check this on https://linkie.shedaniel.dev
-cloth_version=21.11.153
-modmenu_version=17.0.0-beta.2
+cloth_version=26.1.154
+modmenu_version=18.0.0-beta.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/io/github/thevoidblock/nofortunechest/NonSilkWarning.java
+++ b/src/main/java/io/github/thevoidblock/nofortunechest/NonSilkWarning.java
@@ -2,16 +2,17 @@ package io.github.thevoidblock.nofortunechest;
 
 import me.shedaniel.autoconfig.AutoConfig;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.minecraft.block.Blocks;
-import net.minecraft.enchantment.Enchantment;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.registry.entry.RegistryEntry;
-import net.minecraft.text.Text;
-import net.minecraft.util.hit.BlockHitResult;
-import net.minecraft.util.hit.HitResult;
-import net.minecraft.world.GameMode;
+import net.minecraft.core.Holder;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -27,14 +28,15 @@ public class NonSilkWarning {
             if(
                     config.modEnabled &&
                     client.player != null &&
-                    client.player.getGameMode() == GameMode.SURVIVAL
+                    client.gameMode != null &&
+                    client.gameMode.getPlayerMode() == GameType.SURVIVAL
             ) {
 
                 AtomicBoolean isSuitable = new AtomicBoolean(true);
 
-                ItemStack itemStack = client.player.getInventory().getSelectedStack();
+                ItemStack itemStack = client.player.getInventory().getSelectedItem();
 
-                Set<RegistryEntry<Enchantment>> enchantments = itemStack.getEnchantments().getEnchantments();
+                Set<Holder<Enchantment>> enchantments = itemStack.getEnchantments().keySet();
                 Item item = itemStack.getItem();
 
                 if(
@@ -42,7 +44,7 @@ public class NonSilkWarning {
                             item.equals(Items.NETHERITE_PICKAXE) ||
                             item.equals(Items.DIAMOND_PICKAXE)
                         ) &&
-                        enchantments.stream().noneMatch(enchantmentRegistryEntry -> enchantmentRegistryEntry.getKey().get().getValue().getPath().equalsIgnoreCase("silk_touch"))
+                        enchantments.stream().noneMatch(enchantment -> enchantment.is(Enchantments.SILK_TOUCH))
                 ) {
                     isSuitable.set(false);
                 }
@@ -50,32 +52,32 @@ public class NonSilkWarning {
                 BlockHitResult result = null;
 
                 if(
-                        client.crosshairTarget != null &&
-                        client.crosshairTarget.getType() == HitResult.Type.BLOCK
-                ) result = (BlockHitResult) client.crosshairTarget;
+                        client.hitResult != null &&
+                        client.hitResult.getType() == HitResult.Type.BLOCK
+                ) result = (BlockHitResult) client.hitResult;
 
-                assert client.world != null;
+                assert client.level != null;
 
                 if (
                         !isSuitable.get() &&
-                        result != null && result.getType() == BlockHitResult.Type.BLOCK &&
-                        client.world.getBlockState(result.getBlockPos()).getBlock() == Blocks.ENDER_CHEST
+                        result != null && result.getType() == HitResult.Type.BLOCK &&
+                        client.level.getBlockState(result.getBlockPos()).getBlock() == Blocks.ENDER_CHEST
                 ) {
                     hasLooked.set(true);
-                    if(config.warningEnabled) client.player.sendMessage(Text.literal(config.warningMessage).withColor(config.warningColor), true);
+                    if(config.warningEnabled) client.player.sendOverlayMessage(Component.literal(config.warningMessage).withColor(config.warningColor));
 
                     if(
                             config.titleEnabled &&
-                            client.options.attackKey.isPressed() &&
+                            client.options.keyAttack.isDown() &&
                             !hasAttacked.get()
                     ) {
-                        client.inGameHud.setTitle(Text.literal(config.titleMessage).withColor(config.titleColor));
+                        client.gui.setTitle(Component.literal(config.titleMessage).withColor(config.titleColor));
                         hasAttacked.set(true);
                     }
 
                 } else if(hasLooked.get()) {
-                    client.inGameHud.clearTitle();
-                    client.inGameHud.setOverlayMessage(Text.empty(), false);
+                    client.gui.clearTitles();
+                    client.gui.setOverlayMessage(Component.empty(), false);
                     hasAttacked.set(false);
                     hasLooked.set(false);
                 }

--- a/src/main/java/io/github/thevoidblock/nofortunechest/gui/ConfigMenu.java
+++ b/src/main/java/io/github/thevoidblock/nofortunechest/gui/ConfigMenu.java
@@ -5,8 +5,8 @@ import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.clothconfig2.api.ConfigBuilder;
 import me.shedaniel.clothconfig2.api.ConfigCategory;
 import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
 
 import static io.github.thevoidblock.nofortunechest.NoFortuneChest.MOD_ID;
 
@@ -16,58 +16,58 @@ public class ConfigMenu {
 
         ConfigBuilder builder = ConfigBuilder.create()
                 .setParentScreen(parent)
-                .setTitle(Text.translatable(String.format("nofortunechestconfig.%s.config", MOD_ID)));
+                .setTitle(Component.translatable(String.format("nofortunechestconfig.%s.config", MOD_ID)));
 
         builder.setSavingRunnable(() -> AutoConfig.getConfigHolder(ModConfig.class).save());
 
-        ConfigCategory general = builder.getOrCreateCategory(Text.translatable(String.format("category.%s.general", MOD_ID)));
+        ConfigCategory general = builder.getOrCreateCategory(Component.translatable(String.format("category.%s.general", MOD_ID)));
 
         ConfigEntryBuilder entryBuilder = builder.entryBuilder();
 
-        general.addEntry(entryBuilder.startBooleanToggle(Text.translatable(String.format("option.%s.mod_toggle", MOD_ID)), config.modEnabled)
+        general.addEntry(entryBuilder.startBooleanToggle(Component.translatable(String.format("option.%s.mod_toggle", MOD_ID)), config.modEnabled)
                 .setDefaultValue(new ModConfig().modEnabled)
                 .setSaveConsumer(newValue -> config.modEnabled = newValue)
                 .build()
         );
 
         //Warning config
-        general.addEntry(entryBuilder.startBooleanToggle(Text.translatable(String.format("option.%s.warning_toggle", MOD_ID)), config.warningEnabled)
+        general.addEntry(entryBuilder.startBooleanToggle(Component.translatable(String.format("option.%s.warning_toggle", MOD_ID)), config.warningEnabled)
                 .setDefaultValue(new ModConfig().warningEnabled)
                 .setSaveConsumer(newValue -> config.warningEnabled = newValue)
                 .build()
         );
 
-        general.addEntry(entryBuilder.startStrField(Text.translatable(String.format("option.%s.warning_message", MOD_ID)), config.warningMessage)
+        general.addEntry(entryBuilder.startStrField(Component.translatable(String.format("option.%s.warning_message", MOD_ID)), config.warningMessage)
                 .setDefaultValue(new ModConfig().warningMessage)
-                .setTooltip(Text.translatable(String.format("tooltip.%s.warning_message", MOD_ID)))
+                .setTooltip(Component.translatable(String.format("tooltip.%s.warning_message", MOD_ID)))
                 .setSaveConsumer(newValue -> config.warningMessage = newValue)
                 .build()
         );
 
-        general.addEntry(entryBuilder.startColorField(Text.translatable(String.format("option.%s.warning_color", MOD_ID)), config.warningColor)
+        general.addEntry(entryBuilder.startColorField(Component.translatable(String.format("option.%s.warning_color", MOD_ID)), config.warningColor)
                 .setDefaultValue(new ModConfig().warningColor)
-                .setTooltip(Text.translatable(String.format("tooltip.%s.warning_color", MOD_ID)))
+                .setTooltip(Component.translatable(String.format("tooltip.%s.warning_color", MOD_ID)))
                 .setSaveConsumer(newValue -> config.warningColor = newValue)
                 .build()
         );
 
         //Title config
-        general.addEntry(entryBuilder.startBooleanToggle(Text.translatable(String.format("option.%s.title_toggle", MOD_ID)), config.titleEnabled)
+        general.addEntry(entryBuilder.startBooleanToggle(Component.translatable(String.format("option.%s.title_toggle", MOD_ID)), config.titleEnabled)
                 .setDefaultValue(new ModConfig().titleEnabled)
                 .setSaveConsumer(newValue -> config.titleEnabled = newValue)
                 .build()
         );
 
-        general.addEntry(entryBuilder.startStrField(Text.translatable(String.format("option.%s.title_message", MOD_ID)), config.titleMessage)
+        general.addEntry(entryBuilder.startStrField(Component.translatable(String.format("option.%s.title_message", MOD_ID)), config.titleMessage)
                 .setDefaultValue(new ModConfig().titleMessage)
-                .setTooltip(Text.translatable(String.format("tooltip.%s.title_message", MOD_ID)))
+                .setTooltip(Component.translatable(String.format("tooltip.%s.title_message", MOD_ID)))
                 .setSaveConsumer(newValue -> config.titleMessage = newValue)
                 .build()
         );
 
-        general.addEntry(entryBuilder.startColorField(Text.translatable(String.format("option.%s.title_color", MOD_ID)), config.warningColor)
+        general.addEntry(entryBuilder.startColorField(Component.translatable(String.format("option.%s.title_color", MOD_ID)), config.warningColor)
                 .setDefaultValue(new ModConfig().titleColor)
-                .setTooltip(Text.translatable(String.format("tooltip.%s.title_color", MOD_ID)))
+                .setTooltip(Component.translatable(String.format("tooltip.%s.title_color", MOD_ID)))
                 .setSaveConsumer(newValue -> config.titleColor = newValue)
                 .build()
         );

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,9 @@
   },
   "depends": {
     "fabricloader": ">=${loader_version}",
-    "fabric": "*",
-    "minecraft": "${minecraft_version}"
+    "minecraft": "~${minecraft_version}",
+    "java": ">=25",
+    "fabric-api": "*",
+    "cloth-config2": ">=${cloth_version}"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
   },
   "depends": {
     "fabricloader": ">=${loader_version}",
-    "minecraft": "~${minecraft_version}",
+    "minecraft": "~26.1",
     "java": ">=25",
     "fabric-api": "*",
     "cloth-config2": ">=${cloth_version}"


### PR DESCRIPTION
## Changes

- Updated Fabric build configuration for Minecraft 26.1.2
- Switched from legacy `fabric-loom`/Yarn mappings to `net.fabricmc.fabric-loom`
- Removed Yarn mappings dependency
- Updated dependencies:
  - Fabric Loader `0.19.2`
  - Fabric API `0.150.0+26.1.2`
  - Cloth Config `26.1.154`
  - Mod Menu `18.0.0-beta.1`
- Updated Gradle wrapper to `9.4.0`
- Raised Java compatibility from 21 to 25
- Updated `fabric.mod.json` dependency metadata
- Migrated Minecraft imports and API calls to Mojang/26.1.2 names
